### PR TITLE
Add error_of method to TreeNode

### DIFF
--- a/mdsthin/ext/tree.py
+++ b/mdsthin/ext/tree.py
@@ -822,6 +822,9 @@ class TreeNode(_NCI):
     def dim_of(self):
         return self._conn.get(f'dim_of({self.fullpath})')
 
+    def error_of(self):
+        return self._conn.get(f'error_of({self.fullpath})')
+
 class classmethodX(object):
     def __get__(self, inst, cls):
         if inst is None:


### PR DESCRIPTION
I don't believe there is currently a convenient way to extract the error field of a signal through the external mdsthin API.
This PR adds a method to do that.